### PR TITLE
Added validating webhook configuration package bundle changes

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -518,7 +518,7 @@ func createPackagedService(phase string) *corev1.Service {
 	return service
 }
 
-func createPackageConfiguration(webhook webhooks.Webhook, phase string) admissionregv1.ValidatingWebhookConfiguration {
+func createPackagedValidatingWebhookConfiguration(webhook webhooks.Webhook, phase string) admissionregv1.ValidatingWebhookConfiguration {
 	webhookConfiguration := createValidatingWebhookConfiguration(webhook)
 	uri := webhook.GetURI()
 	url := "https://" + serviceName + ".{{.package.metadata.namespace}}.svc.cluster.local" + uri
@@ -740,7 +740,7 @@ func main() {
 				continue
 			}
 
-			packageResources = append(packageResources, runtime.RawExtension{Raw: syncset.Encode(createPackageConfiguration(hook(), webhooksPhase))})
+			packageResources = append(packageResources, runtime.RawExtension{Raw: syncset.Encode(createPackagedValidatingWebhookConfiguration(hook(), webhooksPhase))})
 		}
 		var rb strings.Builder
 		for _, packageResource := range packageResources {

--- a/build/resources.go
+++ b/build/resources.go
@@ -36,10 +36,14 @@ const (
 	deployPhase string = "deploy"
 	// Defines the 'config' package-operator phase for any resources related to MCVW configuration
 	configPhase string = "config"
+	// Defines the 'webhooks' package-operator phase for any resources related to MCVW configuration
+	webhooksPhase string = "webhooks"
 	// Defines the label for targeting hypershift cluster taints/tolerations
 	hsControlPlaneLabel = "hypershift.openshift.io/hosted-control-plane"
 	// Defines the label for targeting hypershift control plane taints/tolerations
 	hsClusterLabel = "hypershift.openshift.io/cluster"
+	//caBundle annotation
+	caBundleAnnotation = "service.beta.openshift.io/inject-cabundle"
 )
 
 var (
@@ -514,6 +518,18 @@ func createPackagedService(phase string) *corev1.Service {
 	return service
 }
 
+func createPackageConfiguration(webhook webhooks.Webhook, phase string) admissionregv1.ValidatingWebhookConfiguration {
+	webhookConfiguration := createValidatingWebhookConfiguration(webhook)
+	uri := webhook.GetURI()
+	url := "https://" + serviceName + ".{{.package.metadata.namespace}}.svc.cluster.local" + uri
+	webhookConfiguration.Annotations[pkoPhaseAnnotation] = phase
+	webhookConfiguration.Annotations[caBundleAnnotation] = "false"
+	webhookConfiguration.Webhooks[0].ClientConfig = admissionregv1.WebhookClientConfig{
+		URL: &url,
+	}
+	return webhookConfiguration
+}
+
 // hookToResources turns a Webhook into a ValidatingWebhookConfiguration and Service.
 // The Webhook is expected to implement Rules() which will return a
 func createValidatingWebhookConfiguration(hook webhooks.Webhook) admissionregv1.ValidatingWebhookConfiguration {
@@ -680,7 +696,7 @@ func main() {
 			panic(fmt.Sprintf("Failed to write to %s: %s\n", *templateFile, err.Error()))
 		}
 	} else {
-		fmt.Printf("No -syncsetfile option supplied, will not generate selector sync set")
+		fmt.Printf("No -syncsetfile option supplied, will not generate selector sync set\n")
 	}
 
 	if buildPackage {
@@ -692,6 +708,40 @@ func main() {
 		packageResources = append(packageResources, runtime.RawExtension{Object: createPackagedService(deployPhase)})
 		packageResources = append(packageResources, runtime.RawExtension{Object: createPackagedDeployment(int32(*replicas), deployPhase)})
 
+		hookNames := make([]string, 0)
+		for name := range webhooks.Webhooks {
+			hookNames = append(hookNames, name)
+		}
+		sort.Strings(hookNames)
+		seen := make(map[string]bool)
+		for _, hookName := range hookNames {
+			hook := webhooks.Webhooks[hookName]
+			if seen[hook().GetURI()] {
+				panic(fmt.Sprintf("Duplicate hook URI: %s", hook().GetURI()))
+			}
+			seen[hook().GetURI()] = true
+
+			if !hook().HypershiftEnabled() {
+				continue
+			}
+
+			// no rules...?
+			if len(hook().Rules()) == 0 {
+				continue
+			}
+
+			if *showHookNames {
+				fmt.Println(hook().Name())
+			}
+			if sliceContains(hook().Name(), skip) {
+				continue
+			}
+			if len(onlyInclude) > 0 && !sliceContains(hook().Name(), onlyInclude) {
+				continue
+			}
+
+			packageResources = append(packageResources, runtime.RawExtension{Raw: syncset.Encode(createPackageConfiguration(hook(), webhooksPhase))})
+		}
 		var rb strings.Builder
 		for _, packageResource := range packageResources {
 			resourceYaml, err := yaml.Marshal(packageResource)
@@ -707,6 +757,6 @@ func main() {
 			panic(fmt.Sprintf("Failed to write to %s: %s", fname, err.Error()))
 		}
 	} else {
-		fmt.Printf("No -packagedir option supplied, will not generate package manifest")
+		fmt.Printf("No -packagedir option supplied, will not generate package manifest\n")
 	}
 }

--- a/config/package/manifest.yaml
+++ b/config/package/manifest.yaml
@@ -6,6 +6,8 @@ spec:
   scopes:
     - Namespaced
   phases:
+    - name: webhooks
+      class: hosted-cluster
     - name: rbac
     - name: config
     - name: deploy

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -135,3 +135,215 @@ spec:
           name: webhook-cert
         name: service-ca
 status: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
+  name: sre-namespace-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/namespace-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: namespace-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - namespaces
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
+  name: sre-regular-user-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/regularuser-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: regular-user-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - cloudcredential.openshift.io
+    - machine.openshift.io
+    - admissionregistration.k8s.io
+    - addons.managed.openshift.io
+    - cloudingress.managed.openshift.io
+    - managed.openshift.io
+    - ocmagent.managed.openshift.io
+    - splunkforwarder.managed.openshift.io
+    - upgrade.managed.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - '*/*'
+    scope: '*'
+  - apiGroups:
+    - autoscaling.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - clusterautoscalers
+    - machineautoscalers
+    scope: '*'
+  - apiGroups:
+    - config.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - clusterversions
+    - clusterversions/status
+    - schedulers
+    - apiservers
+    - proxies
+    scope: '*'
+  - apiGroups:
+    - ""
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - configmaps
+    scope: '*'
+  - apiGroups:
+    - machineconfiguration.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - machineconfigs
+    - machineconfigpools
+    scope: '*'
+  - apiGroups:
+    - operator.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - kubeapiservers
+    - openshiftapiservers
+    scope: '*'
+  - apiGroups:
+    - ""
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - nodes
+    - nodes/*
+    scope: '*'
+  - apiGroups:
+    - managed.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - subjectpermissions
+    - subjectpermissions/*
+    scope: '*'
+  - apiGroups:
+    - network.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - '*'
+    resources:
+    - netnamespaces
+    - netnamespaces/*
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
+  name: sre-scc-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/scc-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: scc-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - securitycontextconstraints
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
+  name: sre-techpreviewnoupgrade-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/techpreviewnoupgrade-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: techpreviewnoupgrade-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - config.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - featuregates
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 1

--- a/pkg/webhooks/clusterlogging/clusterlogging.go
+++ b/pkg/webhooks/clusterlogging/clusterlogging.go
@@ -281,6 +281,8 @@ func (s *ClusterloggingWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return customLabelSelector
 }
 
+func (s *ClusterloggingWebhook) HypershiftEnabled() bool { return false }
+
 // NewWebhook creates a new webhook
 func NewWebhook() *ClusterloggingWebhook {
 	scheme := runtime.NewScheme()

--- a/pkg/webhooks/hiveownership/hiveownership.go
+++ b/pkg/webhooks/hiveownership/hiveownership.go
@@ -129,6 +129,8 @@ func (s *HiveOwnershipWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
 
+func (s *HiveOwnershipWebhook) HypershiftEnabled() bool { return false }
+
 // NewWebhook creates a new webhook
 func NewWebhook() *HiveOwnershipWebhook {
 	scheme := runtime.NewScheme()

--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -318,6 +318,8 @@ func (s *NamespaceWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
 
+func (s *NamespaceWebhook) HypershiftEnabled() bool { return true }
+
 // NewWebhook creates a new webhook
 func NewWebhook() *NamespaceWebhook {
 	scheme := runtime.NewScheme()

--- a/pkg/webhooks/pod/pod.go
+++ b/pkg/webhooks/pod/pod.go
@@ -170,6 +170,8 @@ func (s *PodWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
 
+func (s *PodWebhook) HypershiftEnabled() bool { return false }
+
 // NewWebhook creates a new webhook
 func NewWebhook() *PodWebhook {
 	scheme := runtime.NewScheme()

--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -201,3 +201,5 @@ func (s *prometheusruleWebhook) Doc() string {
 func (s *prometheusruleWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
+
+func (s *prometheusruleWebhook) HypershiftEnabled() bool { return false }

--- a/pkg/webhooks/register.go
+++ b/pkg/webhooks/register.go
@@ -43,6 +43,8 @@ type Webhook interface {
 	// SyncSetLabelSelector returns the label selector to use in the SyncSet.
 	// Return utils.DefaultLabelSelector() to stick with the default
 	SyncSetLabelSelector() metav1.LabelSelector
+	//HypershiftEnabled will return boolean value for hypershift enabled configurations
+	HypershiftEnabled() bool
 }
 
 // WebhookFactory return a kind of Webhook

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -350,6 +350,8 @@ func (s *RegularuserWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
 
+func (s *RegularuserWebhook) HypershiftEnabled() bool { return true }
+
 // NewWebhook creates a new webhook
 func NewWebhook() *RegularuserWebhook {
 

--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -215,3 +215,5 @@ func (s *SCCWebHook) Doc() string {
 func (s *SCCWebHook) SyncSetLabelSelector() metav1.LabelSelector {
 	return utils.DefaultLabelSelector()
 }
+
+func (s *SCCWebHook) HypershiftEnabled() bool { return true }

--- a/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
+++ b/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
@@ -85,6 +85,8 @@ func (s *TechPreviewNoUpgradeWebhook) SyncSetLabelSelector() metav1.LabelSelecto
 	return utils.DefaultLabelSelector()
 }
 
+func (s *TechPreviewNoUpgradeWebhook) HypershiftEnabled() bool { return true }
+
 func (s *TechPreviewNoUpgradeWebhook) renderFeatureGate(request admissionctl.Request) (*configv1.FeatureGate, error) {
 	decoder, err := admissionctl.NewDecoder(&s.s)
 	if err != nil {


### PR DESCRIPTION
### What this PR does?

- This PR appends validating webhook configurations to the package bundle which deploy in hosted clusters using pakage operator. 
- It extends changes from https://github.com/openshift/managed-cluster-validating-webhooks/pull/204 for deploying MCVW resource bundle. 

### Testing

```
% go run build/resources.go -showhooks -packagedir config/package/
No -syncsetfile option supplied, will not generate selector sync set
namespace-validation
regular-user-validation
scc-validation
techpreviewnoupgrade-validation
```